### PR TITLE
Base url fix

### DIFF
--- a/nutritionix/nutritionix.py
+++ b/nutritionix/nutritionix.py
@@ -4,7 +4,7 @@ import requests
 import urlparse
 
 API_VERSION = "v2"
-BASE_URL = "https://apibeta.nutritionix.com/%s/" % (API_VERSION)
+BASE_URL = "https://api.nutritionix.com/%s/" % (API_VERSION)
 
 
 class NutritionixClient:


### PR DESCRIPTION
The working base url that seems to work is: https://api.nutritionix.com/v2/
